### PR TITLE
Add signup route

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,11 @@
+import { drizzle } from "drizzle-orm/neon-serverless";
+import { neon } from "@neondatabase/serverless";
+import * as schema from "@shared/schema";
+
+if (!process.env.DATABASE_URL) {
+  throw new Error("DATABASE_URL is not set");
+}
+
+const sql = neon(process.env.DATABASE_URL);
+export const db = drizzle(sql as any, { schema } as any);
+

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,14 @@
+import express from "express";
+import authRoutes from "./routes/auth";
+
+const app = express();
+app.use(express.json());
+
+app.use("/auth", authRoutes);
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Server listening on port ${port}`);
+});
+
+export default app;

--- a/server/routes/auth.ts
+++ b/server/routes/auth.ts
@@ -1,0 +1,36 @@
+import { Router } from "express";
+import { z } from "zod";
+import { db } from "../db";
+import { users } from "@shared/schema";
+import { hashPassword } from "../lib/auth";
+import { eq } from "drizzle-orm";
+
+const auth = Router();
+
+const signupSchema = z.object({
+  email: z.string().email(),
+  password: z.string().min(8),
+  name: z.string().min(1),
+});
+
+auth.post("/signup", async (req, res) => {
+  const parsed = signupSchema.safeParse(req.body);
+  if (!parsed.success) return res.status(400).json({ error: "Invalid input" });
+  const { email, password, name } = parsed.data;
+
+  const existing = (await db
+    .select()
+    .from(users as any)
+    .where(eq((users as any).email, email))) as any[];
+  if (existing.length > 0) return res.status(409).json({ error: "Email already registered" });
+
+  const passwordHash = await hashPassword(password);
+  const inserted = (await db
+    .insert(users as any)
+    .values({ email, passwordHash, name })
+    .returning()) as any[];
+
+  res.status(201).json({ id: inserted[0].id, email: inserted[0].email });
+});
+
+export default auth;


### PR DESCRIPTION
## Summary
- implement `/auth/signup` route
- create minimal database client
- mount auth routes in express server

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6842076b71088323819525a73c466264