### PR TITLE
Add .env instructions and dotenv support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Copy this file to .env and fill in your database connection string
+DATABASE_URL=

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
 # prax_rep_2
 
 A small change to test the Codex PR workflow.
+
+## Setup
+
+Create a `.env` file in the project root based on `.env.example` and set
+`DATABASE_URL` to your PostgreSQL connection string. The server will not start
+without this value.

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "^16.4.5",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4380,6 +4381,18 @@
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.5.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/drizzle-kit": {

--- a/package.json
+++ b/package.json
@@ -75,7 +75,8 @@
     "wouter": "^3.3.5",
     "ws": "^8.18.0",
     "zod": "^3.24.2",
-    "zod-validation-error": "^3.4.0"
+    "zod-validation-error": "^3.4.0",
+    "dotenv": "^16.4.5"
   },
   "devDependencies": {
     "@replit/vite-plugin-cartographer": "^0.2.7",

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,3 +1,4 @@
+import "dotenv/config";
 import { drizzle } from "drizzle-orm/neon-serverless";
 import { neon } from "@neondatabase/serverless";
 import * as schema from "@shared/schema";


### PR DESCRIPTION
## Summary
- add dotenv example and load automatically
- document `.env` setup in README
- install `dotenv`

## Testing
- `npm run check`
- `npm run dev` (with `.env` present)

------
https://chatgpt.com/codex/tasks/task_e_684209166b308323a73875ad58ee5b46