### PR TITLE
Improve DATABASE_URL messaging

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,4 @@
 # Copy this file to .env and fill in your database connection string
+# Example:
+# DATABASE_URL=postgres://user:password@localhost:5432/mydb
 DATABASE_URL=

--- a/server/db.ts
+++ b/server/db.ts
@@ -2,9 +2,16 @@ import "dotenv/config";
 import { drizzle } from "drizzle-orm/neon-serverless";
 import { neon } from "@neondatabase/serverless";
 import * as schema from "@shared/schema";
+import { existsSync } from "fs";
+
+const hasEnv = existsSync(".env");
 
 if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL is not set");
+  const msg = hasEnv
+    ? "DATABASE_URL is not set. Did you forget to add it to your .env file?"
+    :
+        "DATABASE_URL is not set. Create a .env file in the project root based on .env.example";
+  throw new Error(msg);
 }
 
 const sql = neon(process.env.DATABASE_URL);


### PR DESCRIPTION
## Summary
- enhance error when `DATABASE_URL` is missing
- show example connection string in `.env.example`

## Testing
- `npm run check`
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68420c7c15fc8323b57bb01d3a426d1f